### PR TITLE
Remove pip.req import to prevent installation error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,9 @@
 import os
-import pip.req
 import uuid
 import setuptools
 
 
 VERSION = '0.0.1'
-
-#reqs = pip.req.parse_requirements(
-#        os.path.join(os.path.dirname(__file__),
-#            "requirements.txt"), session=uuid.uuid1())
 
 test_requirements = ['pytest==2.7.2', 'pytest-cov==2.0.0', 'flake8']
 


### PR DESCRIPTION
This fixes an installation error on recent versions of `pip`.

I was unable to get any response from the original maintainer and your fork has some useful fixes.